### PR TITLE
Fixed homepage tagline

### DIFF
--- a/src/app/component/hero.tsx
+++ b/src/app/component/hero.tsx
@@ -10,7 +10,7 @@ const Hero = () => {
           <div className="md:w-1/2 text-left space-y-6 sm:px-4 sm:py-6">
             {/* Heading */}
             <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold text-[#2A254B] sm:mb-4 lg:mb-48">
-              The furniture brand for the future&apo;, with timeless designs
+              The furniture brand for the future&apos;s lifestyle, with timeless designs
             </h2>
             {/* Paragraph */}
             <p className="text-lg md:text-xl text-[#2A254B] leading-relaxed sm:mb-6">


### PR DESCRIPTION
This tiny PR corrects a small typo in the homepage tagline text. 
Before : 
<img width="1060" height="608" alt="Screenshot 2025-08-05 145225" src="https://github.com/user-attachments/assets/40b45434-8138-417e-8cbe-77351bec4b1a" />

After : 
<img width="1219" height="697" alt="Screenshot 2025-08-05 143510" src="https://github.com/user-attachments/assets/ff8d7961-3774-4e71-87ad-1e153e38c94d" />
